### PR TITLE
[fix]migrationファイルのtypoを修正

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -23,7 +23,7 @@ class CreateUsersTable extends Migration
             $table->string('image_pass')->nullable();
             $table->integer('age')->nullable();
             $table->integer('sex')->nullable();
-            $table->string('insurance_compnay')->nullable();
+            $table->string('insurance_company')->nullable();
             $table->boolean('spouse')->nullable();
             $table->integer('children')->nullable();
             $table->integer('house_type')->nullable();

--- a/database/migrations/2021_05_23_044608_create_interested_insurances_table.php
+++ b/database/migrations/2021_05_23_044608_create_interested_insurances_table.php
@@ -19,9 +19,9 @@ class CreateInterestedInsurancesTable extends Migration
             $table->boolean('interested_life')->nullable();
             $table->boolean('interested_medical')->nullable();
             $table->boolean('interested_cancer')->nullable();
-            $table->boolean('interesetd_pension')->nullable();
-            $table->boolean('interesetd_saving')->nullable();
-            $table->boolean('interesetd_all_life')->nullable();
+            $table->boolean('interested_pension')->nullable();
+            $table->boolean('interested_saving')->nullable();
+            $table->boolean('interested_all_life')->nullable();
             $table->boolean('interested_home')->nullable();
             $table->boolean('interested_other')->nullable();
         });


### PR DESCRIPTION
【説明文】
users_migrationファイルのinsurance_companyの文字を修正
文字を誤って記載していたため

【コマンド】
php artisan migrate:refresh --seed

【期待される結果】
migrationファイルを全部ロールバックして、再度マイグレーションし直すことで、正しいカラムのテーブルが作成される。
--seedを使うことにより、シードファイルも実行されることにより、テストデータも格納されます。
