### PR TITLE
[add] post編集機能と削除機能の追加

### DIFF
--- a/app/Http/Requests/CreatePostRule.php
+++ b/app/Http/Requests/CreatePostRule.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Validation\Rule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreatePostRule extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => ['required'],
+            'trouble_type' => ['required', 'integer', 'min:1', 'max:5'],
+            'insurance_target' => ['required', 'integer', 'min:1', 'max:9'],
+            'interested_insurances' => ['required', 'array'],
+            'interested_insurances.*' => ['in:life,medical,cancer,pension,saving,all_life,home,other'],
+            'trouble_content' => ['required', 'max:255'],            
+        ];
+    }
+
+    public function messages() {
+        return [
+            'title.required' => '「タイトル」は入力必須です。',
+
+            'trouble_type.required' => '「悩みのタイプ」は入力必須です。',
+            'trouble_type.min.max.integer' => '「悩みのタイプ」に不正な値が入力されました。',
+            'trouble_type.max' => '「悩みのタイプ」に不正な値が入力されました。',
+            'trouble_type.integer' => '「悩みのタイプ」に不正な値が入力されました。',
+
+            'insurance_target.required' => '「誰に対する悩み？」は入力必須です。',
+            'insurance_target.min.max.integer' => '「誰に対する悩み？」に不正な値が入力されました。',
+            'insurance_target.max' => '「誰に対する悩み？」に不正な値が入力されました。',
+            'insurance_target.integer' => '「誰に対する悩み？」に不正な値が入力されました。',
+
+            'interested_insurances.required' => '「興味のある保険」は入力必須です。',
+            'interested_insurances.array' => '「興味のある保険」に不正な値が入力されました。',
+            'interested_insurances.*.in' => '「興味のある保険」に不正な値が入力されました。',
+
+            'trouble_content.required' => '「悩みの内容」は入力必須です。',
+            'trouble_content.max' => '「悩みの内容」は255文字以内でお願いいたします',
+        ];
+    }
+}

--- a/app/Http/Requests/CreatePostRule.php
+++ b/app/Http/Requests/CreatePostRule.php
@@ -39,12 +39,12 @@ class CreatePostRule extends FormRequest
             'title.required' => '「タイトル」は入力必須です。',
 
             'trouble_type.required' => '「悩みのタイプ」は入力必須です。',
-            'trouble_type.min.max.integer' => '「悩みのタイプ」に不正な値が入力されました。',
+            'trouble_type.min' => '「悩みのタイプ」に不正な値が入力されました。',
             'trouble_type.max' => '「悩みのタイプ」に不正な値が入力されました。',
             'trouble_type.integer' => '「悩みのタイプ」に不正な値が入力されました。',
 
             'insurance_target.required' => '「誰に対する悩み？」は入力必須です。',
-            'insurance_target.min.max.integer' => '「誰に対する悩み？」に不正な値が入力されました。',
+            'insurance_target.min' => '「誰に対する悩み？」に不正な値が入力されました。',
             'insurance_target.max' => '「誰に対する悩み？」に不正な値が入力されました。',
             'insurance_target.integer' => '「誰に対する悩み？」に不正な値が入力されました。',
 

--- a/app/Http/Requests/EditPostRule.php
+++ b/app/Http/Requests/EditPostRule.php
@@ -38,12 +38,12 @@ class EditPostRule extends FormRequest
             'title.required' => '「タイトル」は入力必須です。',
 
             'trouble_type.required' => '「悩みのタイプ」は入力必須です。',
-            'trouble_type.min.max.integer' => '「悩みのタイプ」に不正な値が入力されました。',
+            'trouble_type.min' => '「悩みのタイプ」に不正な値が入力されました。',
             'trouble_type.max' => '「悩みのタイプ」に不正な値が入力されました。',
             'trouble_type.integer' => '「悩みのタイプ」に不正な値が入力されました。',
 
             'insurance_target.required' => '「誰に対する悩み？」は入力必須です。',
-            'insurance_target.min.max.integer' => '「誰に対する悩み？」に不正な値が入力されました。',
+            'insurance_target.min' => '「誰に対する悩み？」に不正な値が入力されました。',
             'insurance_target.max' => '「誰に対する悩み？」に不正な値が入力されました。',
             'insurance_target.integer' => '「誰に対する悩み？」に不正な値が入力されました。',
 

--- a/app/Http/Requests/EditPostRule.php
+++ b/app/Http/Requests/EditPostRule.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class EditPostRule extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => ['required'],
+            'trouble_type' => ['required', 'integer', 'min:1', 'max:5'],
+            'insurance_target' => ['required', 'integer', 'min:1', 'max:9'],
+            'interested_insurances' => ['required', 'array'],
+            'interested_insurances.*' => ['in:life,medical,cancer,pension,saving,all_life,home,other'],
+            'trouble_content' => ['required', 'max:255'],            
+        ];
+    }
+
+    public function messages() {
+        return [
+            'title.required' => '「タイトル」は入力必須です。',
+
+            'trouble_type.required' => '「悩みのタイプ」は入力必須です。',
+            'trouble_type.min.max.integer' => '「悩みのタイプ」に不正な値が入力されました。',
+            'trouble_type.max' => '「悩みのタイプ」に不正な値が入力されました。',
+            'trouble_type.integer' => '「悩みのタイプ」に不正な値が入力されました。',
+
+            'insurance_target.required' => '「誰に対する悩み？」は入力必須です。',
+            'insurance_target.min.max.integer' => '「誰に対する悩み？」に不正な値が入力されました。',
+            'insurance_target.max' => '「誰に対する悩み？」に不正な値が入力されました。',
+            'insurance_target.integer' => '「誰に対する悩み？」に不正な値が入力されました。',
+
+            'interested_insurances.required' => '「興味のある保険」は入力必須です。',
+            'interested_insurances.array' => '「興味のある保険」に不正な値が入力されました。',
+            'interested_insurances.*.in' => '「興味のある保険」に不正な値が入力されました。',
+
+            'trouble_content.required' => '「悩みの内容」は入力必須です。',
+            'trouble_content.max' => '「悩みの内容」は255文字以内でお願いいたします',
+        ];
+    }
+}

--- a/app/Models/InterestedInsurance.php
+++ b/app/Models/InterestedInsurance.php
@@ -3,11 +3,22 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class InterestedInsurance extends Model
 {
+    protected $guarded = ['id'];
+    use SoftDeletes;
+
     public function post()
     {
         return $this->hasOne('App\Models\Post');
+    }
+
+    public function getInterestedInsuranceByPostId($id)
+    {
+        $interested_insurance = $this->where('post_id', $id)->firstOrFail();
+        return $interested_insurance;
+        
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -3,10 +3,14 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Auth;
 
 class Post extends Model
 {
     protected $guarded = ['id'];
+    use SoftDeletes;
 
     public function user()
     {
@@ -25,7 +29,7 @@ class Post extends Model
 
     public function getPaginatedPosts()
     {
-        return $this->paginate(10);
+        return $this->orderBy('created_at', 'desc')->paginate(10);
     }
 
     public function getPaginatedSearchResults($word)
@@ -38,5 +42,81 @@ class Post extends Model
     {
         $post = Post::findOrFail($post_id);
         return $post;
+    }
+
+    public function EditPost($request, $post)
+    {
+        $target_insurance = $post->interested_insurance;
+        DB::transaction(function () use ($request, $post, $target_insurance){
+            $post->title = $request->title;
+            $post->trouble_type = $request->trouble_type;
+            $post->insurance_target = $request->insurance_target;
+            $post->trouble_content = $request->trouble_content;
+            $post->save();
+
+            $insurances = ['life' => 0, 'medical' => 0, 'cancer' => 0, 'pension' => 0, 'saving' => 0, 'all_life' => 0, 'home' => 0, 'other' => 0,];
+            //foreachでinterested_insurancesのvalueなカラムにvalueを入れる
+            foreach ($request->interested_insurances as $interested_insurance) {
+                $insurances[$interested_insurance] = 1;
+            }
+
+            $target_insurance->life = $insurances['life'];
+            $target_insurance->medical = $insurances['medical'];
+            $target_insurance->cancer = $insurances['cancer'];
+            $target_insurance->pension = $insurances['pension'];
+            $target_insurance->saving = $insurances['saving'];
+            $target_insurance->all_life = $insurances['all_life'];
+            $target_insurance->home = $insurances['home'];
+            $target_insurance->other = $insurances['other'];
+            $target_insurance->save();
+
+        });
+        return $post;
+    }
+
+    public function createPost($request)
+    {
+        DB::transaction(function () use ($request){
+            $post = $this->create([
+                'user_id' => Auth::id(),
+                'title' => $request->title,
+                'trouble_type' => $request->trouble_type,
+                'insurance_target' => $request->insurance_target,
+                'trouble_content' => $request->trouble_content,
+            ]);
+
+            $insurances = ['life' => 0, 'medical' => 0, 'cancer' => 0, 'pension' => 0, 'saving' => 0, 'all_life' => 0, 'home' => 0, 'other' => 0,];
+
+            //foreachでinterested_insurancesのvalueなカラムにvalueを入れる
+            foreach ($request->interested_insurances as $interested_insurance) {
+                $insurances[$interested_insurance] = 1;
+            }
+            InterestedInsurance::create([
+                'post_id' => $post->id,
+                'life' => $insurances['life'],
+                'medical' => $insurances['medical'],
+                'canner' => $insurances['cancer'],
+                'pension' => $insurances['pension'],
+                'saving' => $insurances['saving'],
+                'all_life' => $insurances['all_life'],
+                'home' => $insurances['home'],
+                'other' => $insurances['other'],
+            ]);
+            
+        });
+        return true;
+    }
+
+    public function deletePostById($id)
+    {
+        $post = $this->getDetailPostById(($id));
+        $interested_insurance = $post->interested_insurance;
+
+        DB::transaction(function () use ($id, $post, $interested_insurance){
+           $post->delete(); 
+           $interested_insurance->delete(); 
+        });
+        return true;
+        
     }
 }

--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -39,9 +39,5 @@ $factory->define(App\Models\Comment::class, function (Faker $faker) {
     },
     'comment' => $faker->text,
     ];
-
-    Log::debug('commetnファクトリの中↓');
-    Log::debug($arr);
-
     return $arr;
 });

--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -1,6 +1,7 @@
 <?php
 
 use Faker\Generator as Faker;
+use Illuminate\Support\Facades\Log;
 
 /*
 |--------------------------------------------------------------------------
@@ -15,13 +16,32 @@ use Faker\Generator as Faker;
 
 $factory->define(App\Models\Comment::class, function (Faker $faker) {
     $date = \Carbon\Carbon::now();
-    return [
+    // return [
+    //     'post_id' => function() {
+    //         // return factory(App\Models\Post::class)->create()->id;
+    //         return factory(App\Models\Post::class);
+    //     },
+    //     'user_id' => function () {
+    //         // return factory(App\Models\User::class)->create()->id;
+    //         return factory(App\Models\User::class);
+    //     },
+    //     'comment' => $faker->text,
+    // ];
+
+    $arr = [
         'post_id' => function() {
-            return factory(App\Models\Post::class)->create()->id;
-        },
-        'user_id' => function () {
-            return factory(App\Models\User::class)->create()->id;
-        },
-        'comment' => $faker->text,
+        // return factory(App\Models\Post::class)->create()->id;
+        return factory(App\Models\Post::class);
+    },
+    'user_id' => function () {
+        // return factory(App\Models\User::class)->create()->id;
+        return factory(App\Models\User::class);
+    },
+    'comment' => $faker->text,
     ];
+
+    Log::debug('commetnファクトリの中↓');
+    Log::debug($arr);
+
+    return $arr;
 });

--- a/database/factories/InterestedInsuranceFactory.php
+++ b/database/factories/InterestedInsuranceFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+use Faker\Generator as Faker;
+use Illuminate\Support\Facades\Log;
+
+$factory->define(App\Models\InterestedInsurance::class, function (Faker $faker) {
+    return [
+        'post_id' => function () {
+            return factory(App\Models\Post::class);
+            // return App\Models\Post::find($post->id);
+        },
+        'life' => $faker->numberBetween(0,1),
+        'medical' => $faker->numberBetween(0,1),
+        'cancer' => $faker->numberBetween(0,1),
+        'pension' => $faker->numberBetween(0,1),
+        'saving' => $faker->numberBetween(0,1),
+        'all_life' => $faker->numberBetween(0,1),
+        'home' => $faker->numberBetween(0,1),
+        'other' => $faker->numberBetween(0,1),
+    ];
+    
+});

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -1,17 +1,33 @@
 <?php
 
 use Faker\Generator as Faker;
+use Illuminate\Support\Facades\Log;
 
 $factory->define(App\Models\Post::class, function (Faker $faker) {
     $date = \Carbon\Carbon::now();
-    return [
+    // return [
+    //     'title' => $faker->jobTitle,
+    //     'trouble_type' => $faker->randomElement(['1', '2', '3', '4', '5']),
+    //     'insurance_target' => $faker->numberBetween(1, 9),
+    //     'trouble_content' => $faker->sentence,
+    //     'user_id' => function () {
+    //         // return factory(App\Models\User::class)->create()->id;
+    //         return factory(App\Models\User::class);
+    //     }
+        
+    // ];
+    $arr1 = [
         'title' => $faker->jobTitle,
         'trouble_type' => $faker->randomElement(['1', '2', '3', '4', '5']),
         'insurance_target' => $faker->numberBetween(1, 9),
         'trouble_content' => $faker->sentence,
         'user_id' => function () {
-            return factory(App\Models\User::class)->create()->id;
+            // return factory(App\Models\User::class)->create()->id;
+            return factory(App\Models\User::class);
         }
-        
     ];
+    Log::debug('postFactoryのなか↓');
+    Log::debug($arr1);
+
+    return $arr1;
 });

--- a/database/migrations/2021_05_23_044608_create_interested_insurances_table.php
+++ b/database/migrations/2021_05_23_044608_create_interested_insurances_table.php
@@ -24,6 +24,8 @@ class CreateInterestedInsurancesTable extends Migration
             $table->boolean('all_life')->nullable();
             $table->boolean('home')->nullable();
             $table->boolean('other')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Log;
 
 class DatabaseSeeder extends Seeder
 {
@@ -18,9 +19,21 @@ class DatabaseSeeder extends Seeder
         $this->call(Family_insuranceTableSeeder::class);
         $this->call(Interested_insuranceTableSeeder::class);
 
-        factory(App\Models\Post::class, 15)->create();
-        factory(App\Models\Comment::class, 15)->create();
+        // factory(App\Models\Post::class, 15)->create();
+        // factory(App\Models\Comment::class, 15)->create();
         factory(App\Models\Good::class, 15)->create();
         factory(App\Models\Relationship::class, 15)->create();
+
+        //postsテーブルとusersテーブルを3件作成する
+        $posts = factory(App\Models\Post::class, 3)->create();
+        //interested_insurancesテーブルを作成
+        $posts->each(function($post){
+            factory(App\Models\InterestedInsurance::class, 1)->create(['post_id' => $post->id]);
+        });
+
+        //作成した$postに対してコメントをそれぞれ３件作成する。キーを指定することで属性をオーバーライドできる
+        $posts->each(function($post){
+            factory(App\Models\Comment::class, 3)->create(['post_id' => $post->id,'user_id' => $post->user_id]);
+        });
     }
 }

--- a/resources/views/post/create.blade.php
+++ b/resources/views/post/create.blade.php
@@ -36,7 +36,7 @@
         <input type="radio" name="insurance_target" value="9" {{ old('insurance_target') == 9  ? 'checked' : ''}}>その他
     </div>
     <div>
-        <label>興味のある保険</label>
+        <label>興味のある保険(複数回答可)</label>
         <input type="checkbox" name="interested_insurances[]" value="life" {{ is_array(old('interested_insurances')) && in_array('life', old('interested_insurances')) ? 'checked' : ''}}>生命保険
         <input type="checkbox" name="interested_insurances[]" value="medical" {{ is_array(old('interested_insurances')) && in_array('medical', old('interested_insurances')) ? 'checked' : ''}}>医療保険
         <input type="checkbox" name="interested_insurances[]" value="cancer" {{ is_array(old('interested_insurances')) && in_array('cancer', old('interested_insurances')) ? 'checked' : ''}}>がん保険

--- a/resources/views/post/create.blade.php
+++ b/resources/views/post/create.blade.php
@@ -1,0 +1,58 @@
+@extends('layouts.app')
+
+@section('content')
+<a href="{{ route('post.index') }}">保険の悩み一覧ページ</a>
+
+<h1>保険の悩み投稿ページ</h1>
+
+@foreach ($errors->all() as $error)
+  <li>{{$error}}</li>
+@endforeach
+
+<form action="{{ route('post.create') }}" method="POST">
+    {{ csrf_field() }}
+    <div>
+        <label>悩みのタイトル</label>
+        <input type="text" name="title" value={{ old('title') }}>
+    </div>
+    <div>
+        <label>どんなタイプの悩み？</label>
+        <input type="radio" name="trouble_type" value="1" {{ old('trouble_type') == 1  ? 'checked' : ''}}>保険加入について
+        <input type="radio" name="trouble_type" value="2" {{ old('trouble_type') == 2  ? 'checked' : ''}}>現在加入の保険について
+        <input type="radio" name="trouble_type" value="3" {{ old('trouble_type') == 3  ? 'checked' : ''}}>健康告知について
+        <input type="radio" name="trouble_type" value="4" {{ old('trouble_type') == 4  ? 'checked' : ''}}>営業マンにおすすめされた保険について
+        <input type="radio" name="trouble_type" value="5" {{ old('trouble_type') == 5  ? 'checked' : ''}}>その他の悩み
+    </div>
+    <div>
+        <label>誰に対する悩み？</label>
+        <input type="radio" name="insurance_target" value="1" {{ old('insurance_target') == 1  ? 'checked' : ''}}>本人
+        <input type="radio" name="insurance_target" value="2" {{ old('insurance_target') == 2  ? 'checked' : ''}}>配偶者
+        <input type="radio" name="insurance_target" value="3" {{ old('insurance_target') == 3  ? 'checked' : ''}}>子供
+        <input type="radio" name="insurance_target" value="4" {{ old('insurance_target') == 4  ? 'checked' : ''}}>親
+        <input type="radio" name="insurance_target" value="5" {{ old('insurance_target') == 5  ? 'checked' : ''}}>祖母
+        <input type="radio" name="insurance_target" value="6" {{ old('insurance_target') == 6  ? 'checked' : ''}}>祖父
+        <input type="radio" name="insurance_target" value="7" {{ old('insurance_target') == 7  ? 'checked' : ''}}>孫
+        <input type="radio" name="insurance_target" value="8" {{ old('insurance_target') == 8  ? 'checked' : ''}}>友人
+        <input type="radio" name="insurance_target" value="9" {{ old('insurance_target') == 9  ? 'checked' : ''}}>その他
+    </div>
+    <div>
+        <label>興味のある保険</label>
+        <input type="checkbox" name="interested_insurances[]" value="life" {{ is_array(old('interested_insurances')) && in_array('life', old('interested_insurances')) ? 'checked' : ''}}>生命保険
+        <input type="checkbox" name="interested_insurances[]" value="medical" {{ is_array(old('interested_insurances')) && in_array('medical', old('interested_insurances')) ? 'checked' : ''}}>医療保険
+        <input type="checkbox" name="interested_insurances[]" value="cancer" {{ is_array(old('interested_insurances')) && in_array('cancer', old('interested_insurances')) ? 'checked' : ''}}>がん保険
+        <input type="checkbox" name="interested_insurances[]" value="pension" {{ is_array(old('interested_insurances')) && in_array('pension', old('interested_insurances')) ? 'checked' : ''}}>生命保険
+        <input type="checkbox" name="interested_insurances[]" value="saving" {{ is_array(old('interested_insurances')) && in_array('saving', old('interested_insurances')) ? 'checked' : ''}}>貯蓄型の保険
+        <input type="checkbox" name="interested_insurances[]" value="all_life" {{ is_array(old('interested_insurances')) && in_array('all_life', old('interested_insurances')) ? 'checked' : ''}}>終身保険
+        <input type="checkbox" name="interested_insurances[]" value="home" {{ is_array(old('interested_insurances')) && in_array('home', old('interested_insurances')) ? 'checked' : ''}}>火災保険
+        <input type="checkbox" name="interested_insurances[]" value="other" {{ is_array(old('interested_insurances')) && in_array('other', old('interested_insurances')) ? 'checked' : ''}}>その他
+
+    </div>
+    <textarea name="trouble_content">{{ old('trouble_content') }}</textarea>
+    <div>
+        <input type="submit" value="悩みを共有してアドバイスをもらう">
+    </div>
+</form>
+<br>
+
+
+@endsection

--- a/resources/views/post/detail.blade.php
+++ b/resources/views/post/detail.blade.php
@@ -5,8 +5,7 @@
 
 
 <h1>悩み詳細</h1>
-<div>
-    <img src="{{ $post->user->image_pass }}" alt="" width="30">
+<div><img src="{{ $post->user->image_pass }}" alt="" width="30">
     <p>
         名前 : <a href="{{ route('profile', ['id' => $post->user->id]) }}">{{ $post->user->name }}</a>
         タイトル : {{ $post->title }}
@@ -57,6 +56,14 @@
     </table>
     <p>→悩みに対するコメントの数 : {{ count($post->comments) }}</p>
 </div>
+
+@if ($post->user_id == Auth::id())
+    <a href="{{ route('post.edit', ['post' => $post]) }}">編集</a>
+    <form method="post" action="{{ route('post.delete', ['post' => $post]) }}">
+        {{ csrf_field() }}
+        <input type="submit" value="削除">
+    </form>
+@endif
 
 @if (!empty($post->comments))
     <p>コメント一覧</p>

--- a/resources/views/post/edit.blade.php
+++ b/resources/views/post/edit.blade.php
@@ -1,0 +1,58 @@
+@extends('layouts.app')
+
+@section('content')
+<a href="{{ route('post.index') }}">保険の悩み一覧ページ</a>
+
+<h1>保険の悩み編集ページ</h1>
+
+@foreach ($errors->all() as $error)
+  <li>{{$error}}</li>
+@endforeach
+
+<form action="{{ route('post.edit', ['post' => $target_post]) }}" method="POST">
+    {{ csrf_field() }}
+    <div>
+        <label>悩みのタイトル</label>
+        <input type="text" name="title" value={{ old('title', $target_post->title) }}>
+    </div>
+    <div>
+        <label>どんなタイプの悩み？</label>
+        <input type="radio" name="trouble_type" value="1" {{ old('trouble_type', $target_post->trouble_type) == 1  ? 'checked' : ''}}>保険加入について
+        <input type="radio" name="trouble_type" value="2" {{ old('trouble_type', $target_post->trouble_type) == 2  ? 'checked' : ''}}>現在加入の保険について
+        <input type="radio" name="trouble_type" value="3" {{ old('trouble_type', $target_post->trouble_type) == 3  ? 'checked' : ''}}>健康告知について
+        <input type="radio" name="trouble_type" value="4" {{ old('trouble_type', $target_post->trouble_type) == 4  ? 'checked' : ''}}>営業マンにおすすめされた保険について
+        <input type="radio" name="trouble_type" value="5" {{ old('trouble_type', $target_post->trouble_type) == 5  ? 'checked' : ''}}>その他の悩み
+    </div>
+    <div>
+        <label>誰に対する悩み？</label>
+        <input type="radio" name="insurance_target" value="1" {{ old('insurance_target', $target_post->insurance_target) == 1  ? 'checked' : ''}}>本人
+        <input type="radio" name="insurance_target" value="2" {{ old('insurance_target', $target_post->insurance_target) == 2  ? 'checked' : ''}}>配偶者
+        <input type="radio" name="insurance_target" value="3" {{ old('insurance_target', $target_post->insurance_target) == 3  ? 'checked' : ''}}>子供
+        <input type="radio" name="insurance_target" value="4" {{ old('insurance_target', $target_post->insurance_target) == 4  ? 'checked' : ''}}>親
+        <input type="radio" name="insurance_target" value="5" {{ old('insurance_target', $target_post->insurance_target) == 5  ? 'checked' : ''}}>祖母
+        <input type="radio" name="insurance_target" value="6" {{ old('insurance_target', $target_post->insurance_target) == 6  ? 'checked' : ''}}>祖父
+        <input type="radio" name="insurance_target" value="7" {{ old('insurance_target', $target_post->insurance_target) == 7  ? 'checked' : ''}}>孫
+        <input type="radio" name="insurance_target" value="8" {{ old('insurance_target', $target_post->insurance_target) == 8  ? 'checked' : ''}}>友人
+        <input type="radio" name="insurance_target" value="9" {{ old('insurance_target', $target_post->insurance_target) == 9  ? 'checked' : ''}}>その他
+    </div>
+    <div>
+        <label>興味のある保険</label>
+        <input type="checkbox" name="interested_insurances[]" value="life" {{ is_array(old('interested_insurances', $interested_insurance_arr)) && in_array('life', old('interested_insurances', $interested_insurance_arr)) ? 'checked' : ''}}>生命保険
+        <input type="checkbox" name="interested_insurances[]" value="medical" {{ is_array(old('interested_insurances', $interested_insurance_arr)) && in_array('medical', old('interested_insurances', $interested_insurance_arr)) ? 'checked' : ''}}>医療保険
+        <input type="checkbox" name="interested_insurances[]" value="cancer" {{ is_array(old('interested_insurances', $interested_insurance_arr)) && in_array('cancer', old('interested_insurances', $interested_insurance_arr)) ? 'checked' : ''}}>がん保険
+        <input type="checkbox" name="interested_insurances[]" value="pension" {{ is_array(old('interested_insurances', $interested_insurance_arr)) && in_array('pension', old('interested_insurances', $interested_insurance_arr)) ? 'checked' : ''}}>年金保険
+        <input type="checkbox" name="interested_insurances[]" value="saving" {{ is_array(old('interested_insurances', $interested_insurance_arr)) && in_array('saving', old('interested_insurances', $interested_insurance_arr)) ? 'checked' : ''}}>貯蓄型の保険
+        <input type="checkbox" name="interested_insurances[]" value="all_life" {{ is_array(old('interested_insurances', $interested_insurance_arr)) && in_array('all_life', old('interested_insurances', $interested_insurance_arr)) ? 'checked' : ''}}>終身保険
+        <input type="checkbox" name="interested_insurances[]" value="home" {{ is_array(old('interested_insurances', $interested_insurance_arr)) && in_array('home', old('interested_insurances', $interested_insurance_arr)) ? 'checked' : ''}}>火災保険
+        <input type="checkbox" name="interested_insurances[]" value="other" {{ is_array(old('interested_insurances', $interested_insurance_arr)) && in_array('other', old('interested_insurances', $interested_insurance_arr)) ? 'checked' : ''}}>その他
+
+    </div>
+    <textarea name="trouble_content">{{ old('trouble_content', $target_post->trouble_content) }}</textarea>
+    <div>
+        <input type="submit" value="悩みを共有してアドバイスをもらう">
+    </div>
+</form>
+<br>
+
+
+@endsection

--- a/resources/views/post/edit.blade.php
+++ b/resources/views/post/edit.blade.php
@@ -36,7 +36,7 @@
         <input type="radio" name="insurance_target" value="9" {{ old('insurance_target', $target_post->insurance_target) == 9  ? 'checked' : ''}}>その他
     </div>
     <div>
-        <label>興味のある保険</label>
+        <label>興味のある保険(複数回答可)</label>
         <input type="checkbox" name="interested_insurances[]" value="life" {{ is_array(old('interested_insurances', $interested_insurance_arr)) && in_array('life', old('interested_insurances', $interested_insurance_arr)) ? 'checked' : ''}}>生命保険
         <input type="checkbox" name="interested_insurances[]" value="medical" {{ is_array(old('interested_insurances', $interested_insurance_arr)) && in_array('medical', old('interested_insurances', $interested_insurance_arr)) ? 'checked' : ''}}>医療保険
         <input type="checkbox" name="interested_insurances[]" value="cancer" {{ is_array(old('interested_insurances', $interested_insurance_arr)) && in_array('cancer', old('interested_insurances', $interested_insurance_arr)) ? 'checked' : ''}}>がん保険

--- a/resources/views/post/index.blade.php
+++ b/resources/views/post/index.blade.php
@@ -3,6 +3,9 @@
 @section('content')
 
 <h1>保険の悩み一覧</h1>
+
+<a href="{{ route('post.create') }}">悩みを投稿する</a>
+
 <form action="{{ route('post.search') }}" method="GET">
     <input type="text" name="word" value={{ old('word') }}>
     <input type="submit" value="検索する">

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,13 +30,13 @@ Route::get('/profile/{id}', 'ProfileController@detail')->name('profile');
 * ログイン後
 */
 Route::group(['prefix' => 'post', 'middleware' => 'auth:user'], function () {
-    Route::get('/create', 'PostController@showCreateForm')->name('post.create');
-    Route::post('/create', 'PostController@create');
+    Route::get('/create', 'PostController@create')->name('post.create');
+    Route::post('/create', 'PostController@store');
 
-    Route::get('/edit/{id}', 'PostController@showEditForm')->name('post.edit');
-    Route::post('/edit/{id}', 'PostController@edit');
+    Route::get('/edit/{post}', 'PostController@edit')->name('post.edit');
+    Route::post('/edit/{post}', 'PostController@update');
 
-    Route::post('/delete/{id}', 'PostController@delete')->name('post.delete');
+    Route::post('/delete/{post}', 'PostController@delete')->name('post.delete');
 
     Route::group(['prefix' => 'comment', 'middleware' => 'auth:user'], function () {
         Route::post('/', 'CommentController@comment')->name('post.comment');


### PR DESCRIPTION
説明文
・post編集機能と削除機能の追加
・factoryで、postsテーブルデータを作成したときにinterested_insurancesテーブルデータも作成できるようにした。
→無駄にレコードが増えないように修正した。(ただし、Postsとinterested_insurances、Commentテーブルのみ)
→現状だとGoodsテーブルで作成したuserレコードが増えていたりcommentファクトリによってuserレコードやpostレコードが増えていると思われる。

コマンド
php artisan migrate:refresh --seed

期待される結果
・ユーザが投稿したpostを編集、削除することができる