### PR TITLE
[fix]プロフィール画像を表示している全ページでデフォルト画像が表示されるように修正

### DIFF
--- a/public/storage
+++ b/public/storage
@@ -1,1 +1,1 @@
-/home/www/hurusawa205/insurance/matching_insurance/storage/app/public
+/home/www/yajima427/insurance_sns/matching_insurance/storage/app/public

--- a/resources/views/post/comment_edit.blade.php
+++ b/resources/views/post/comment_edit.blade.php
@@ -4,7 +4,12 @@
 
 <h1>悩み詳細</h1>
 <div>
-    <img src="{{ $post->user->image_pass }}" alt="" width="30">
+    @if ($post->user->image_pass)
+	    <img src="{{ $post->user->image_pass }}" alt="" width="30">
+	    <img src="{{ asset('storage/image/' . $post->user->image_pass)}}" alt="" width="30"> 
+	@else
+	    <img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="30">
+	@endif
     <p>
         名前 : {{ $post->user->name }}
         タイトル : {{ $post->title }}

--- a/resources/views/post/comment_edit.blade.php
+++ b/resources/views/post/comment_edit.blade.php
@@ -64,7 +64,12 @@
 @if (!empty($post->comments))
     <p>コメント一覧</p>
     @foreach ($post->comments as $comment)
-        <img src="{{ $comment->user->image_pass }}" alt="" width="30">
+        @if ($comment->user->image_pass)
+		    <img src="{{ $comment->user->image_pass }}" alt="" width="30">
+		    <img src="{{ asset('storage/image/' . $comment->user->image_pass)}}" alt="" width="30"> 
+	    @else
+		    <img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="30">
+	    @endif
         <p>
             名前 : {{ $comment->user->name }}
             コメント時間 : {{ $comment->created_at }}

--- a/resources/views/post/detail.blade.php
+++ b/resources/views/post/detail.blade.php
@@ -84,8 +84,15 @@
             <a href="{{route('comment.good', ['comment_id' => $comment->id])}}">いいね</a>
 
         @endif
+    
+    </br>
 
-        <img src="{{ $comment->user->image_pass }}" alt="" width="30">
+        @if ($comment->user->image_pass)
+		    <img src="{{ $comment->user->image_pass }}" alt="" width="30">
+		    <img src="{{ asset('storage/image/' . $comment->user->image_pass)}}" alt="" width="30"> 
+	    @else
+		    <img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="30">
+	    @endif
         <p>
             名前 : {{ $comment->user->name }}
             コメント時間 : {{ $comment->created_at }}

--- a/resources/views/post/detail.blade.php
+++ b/resources/views/post/detail.blade.php
@@ -5,7 +5,13 @@
 
 
 <h1>悩み詳細</h1>
-<div><img src="{{ $post->user->image_pass }}" alt="" width="30">
+<div>
+    @if ($post->user->image_pass)
+	    <img src="{{ $post->user->image_pass }}" alt="" width="30">
+	    <img src="{{ asset('storage/image/' . $post->user->image_pass)}}" alt="" width="30"> 
+    @else
+	    <img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="30">
+    @endif
     <p>
         名前 : <a href="{{ route('profile', ['id' => $post->user->id]) }}">{{ $post->user->name }}</a>
         タイトル : {{ $post->title }}

--- a/resources/views/post/index.blade.php
+++ b/resources/views/post/index.blade.php
@@ -14,7 +14,13 @@
 
 @foreach ($posts as $post)
     <div>
-        <img src="{{ $post->user->image_pass }}" alt="" width="30">
+        @if ($post->user->image_pass)
+		    <img src="{{ $post->user->image_pass }}" alt="" width="30">
+		    <img src="{{ asset('storage/image/' . $post->user->image_pass)}}" alt="" width="30"> 
+	    @else
+		    <img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="30">
+	    @endif
+
         <p>
             名前 :<a href="{{ route('profile', ['id' => $post->user->id]) }}"> {{ $post->user->name }}</a>
             <a href="{{ route('post.detail', ['post_id' => $post->id]) }}">タイトル : {{ $post->title }}</a>

--- a/resources/views/post/search.blade.php
+++ b/resources/views/post/search.blade.php
@@ -18,7 +18,12 @@
 
 @foreach ($posts as $post)
     <div>
-        <img src="{{ $post->user->image_pass }}" alt="" width="30">
+        @if ($post->user->image_pass)
+		    <img src="{{ $post->user->image_pass }}" alt="" width="30">
+		    <img src="{{ asset('storage/image/' . $post->user->image_pass)}}" alt="" width="30"> 
+	    @else
+		    <img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="30">
+	    @endif
         <p>
             名前 : {{ $post->user->name }}
             タイトル : {{ $post->title }}

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -15,7 +15,7 @@
 	<img src="{{ asset('storage/image/' . $user->image_pass)}}" alt="" width="100">
 	<button onclick="location. href='{{route('profile.image_delete', ['id' => $user->id])}}'">画像削除</button>
 @else
-	<p>登録なし</p>
+	<img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="100">
 @endif
 <div>
 	{{Form::open(['url' => route('profile.edit', [$user->id]), 'files' => true])}}


### PR DESCRIPTION
【説明文】
プロフィールのデフォルト画像が表示されるように既存の全ページを修正

【コマンド】
画像を表示させるため、シンボリックリンクの再設定が必要になります。
①publicディレクトリ内でunlink storage
②最初のディレクトリに戻り、php artisan storage:link

【期待される結果】
プロフィールページを表示している全ページでデフォルト画像が、新しいものに全て置き換わっている