### PR TITLE
[add]フォローしているユーザーの投稿とコメントのみ見れるページを作成

### DIFF
--- a/app/Http/Controllers/RelationshipController.php
+++ b/app/Http/Controllers/RelationshipController.php
@@ -5,6 +5,10 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\Relationship;
 use App\Models\User;
+use App\Models\Post;
+use App\Models\Comment;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Auth;
 
 class RelationshipController extends Controller
 {
@@ -54,4 +58,9 @@ class RelationshipController extends Controller
 		return back()->with('success', 'フォロー解除しました');
 	}
 
+	public function followedUsersPostsAndComments(Request $request)
+	{
+		$posts_and_comments = $this->relationship->getFollowedUsersPostsAndComments($request);
+		return view('post.followed_post', compact('posts_and_comments'));
+	}
 }

--- a/app/Models/Relationship.php
+++ b/app/Models/Relationship.php
@@ -89,9 +89,10 @@ class Relationship extends Model
 
 	public function getFollowedUsersPostsAndComments($request)
 	{
-		$followed = $this->where('follower_id', Auth::id())->get();
-		$posts = Post::whereIn('user_id', $followed->pluck('followed_id'))->get();
-		$comments = Comment::whereIn('user_id', $followed->pluck('followed_id'))->get();
+		// ログインユーザーがフォローしているユーザーのid
+		$following_users_id = $this->where('follower_id', Auth::id())->pluck('followed_id');
+		$posts = Post::whereIn('user_id', $following_users_id)->get();
+		$comments = Comment::whereIn('user_id', $following_users_id)->get();
 		$posts_and_comments = $posts->merge($comments)->sortByDesc('created_at');
 		$posts_and_comments = new LengthAwarePaginator(
 			$posts_and_comments->forPage($request->page, 10),

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -48,7 +48,7 @@
                     <!-- Right Side Of Navbar -->
                     <ul class="nav navbar-nav navbar-right">
 						<li><a href="{{ route('ranking.user')}}">ランキング</a><li>
-						<li><a href="{{ route('followed_content')}}">掲示板(フォローユーザーのみ)</a></a><li>
+						<li><a href="{{ route('followed_content')}}">フォロー者投稿</a></a><li>
                         <!-- Authentication Links -->
                         @guest
                             <li><a href="{{ route('login') }}">ログイン</a></li>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -48,6 +48,7 @@
                     <!-- Right Side Of Navbar -->
                     <ul class="nav navbar-nav navbar-right">
 						<li><a href="{{ route('ranking.user')}}">ランキング</a><li>
+						<li><a href="{{ route('followed_content')}}">掲示板(フォローユーザーのみ)</a></a><li>
                         <!-- Authentication Links -->
                         @guest
                             <li><a href="{{ route('login') }}">ログイン</a></li>

--- a/resources/views/post/followed_post.blade.php
+++ b/resources/views/post/followed_post.blade.php
@@ -1,0 +1,112 @@
+@extends('layouts.app')
+
+@section('content')
+
+<h1>掲示版(フォローしているユーザーのみ)</h1>
+@if (empty($posts_and_comments)) 
+    <p>フォローユーザーの投稿とコメントはありません</p>
+@else
+<p>
+    {{ ($posts_and_comments->currentPage()-1) * $posts_and_comments->perPage()+1 }} - 
+    {{ (($posts_and_comments->currentPage()-1) * $posts_and_comments->perPage()+1) + (count($posts_and_comments)-1) }} 件 
+
+    /{{ $posts_and_comments->total() }} 件を表示しています。
+ </p>
+ 
+
+@foreach ($posts_and_comments as $post_and_comment)
+    {{-- postか確認するコード --}}
+    @if (!empty($post_and_comment->trouble_content))
+        <p>悩み投稿</p>
+        @if ($post_and_comment->user->image_pass)
+		    <img src="{{ $post_and_comment->user->image_pass }}" alt="" width="30">
+		    <img src="{{ asset('storage/image/' . $post_and_comment->user->image_pass)}}" alt="" width="30"> 
+	    @else
+		    <img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="30">
+	    @endif
+        <p>
+            <a href="{{ route('profile', ['user_id' => $post_and_comment->user_id]) }}">名前 : {{ $post_and_comment->user->name }}</a>
+            <a href="{{ route('post.detail', ['post_id' => $post_and_comment->id]) }}">タイトル : {{ $post_and_comment->title }}</a>
+            投稿時間 : {{ $post_and_comment->created_at }}
+        </p>
+        <table>
+            <thead>
+                <tr>
+                    <th>悩みの種類</th>
+                    <th>悩みを抱えている人</th>
+                    <th>悩みの内容</th>
+                    <th>興味のある保険を表示</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>{{ config('trouble_type.' . $post_and_comment->trouble_type) }}</td>
+                    <td>{{ config('insurance_target.' . $post_and_comment->insurance_target) }}</td>
+                    <td>{{ $post_and_comment->trouble_content }}</td>
+                    <td>
+                        @if ($post_and_comment->interested_insurance['life'] === 1)
+                           生命保険 
+                        @endif
+                        @if ($post_and_comment->interested_insurance['medical'] === 1)
+                           医療保険 
+                        @endif
+                        @if ($post_and_comment->interested_insurance['cancer']=== 1)
+                           がん保険 
+                        @endif
+                        @if ($post_and_comment->interested_insurance['pension'] === 1)
+                           年金保険 
+                        @endif
+                        @if ($post_and_comment->interested_insurance['saving']=== 1)
+                           貯蓄型の保険 
+                        @endif
+                        @if ($post_and_comment->interested_insurance['all_life'] === 1)
+                           終身保険 
+                        @endif
+                        @if ($post_and_comment->interested_insurance['home'] === 1)
+                           火災保険 
+                        @endif
+                        @if ($post_and_comment->interested_insurance['other'] === 1)
+                           その他 
+                        @endif
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <p>→悩みに対するコメントの数 : {{ count($post_and_comment->comments) }}</p>
+    </div>
+
+    <br>
+    <br>
+
+    @else
+    <p>コメント</p>
+
+    @if ($post_and_comment->user->image_pass)
+        <img src="{{ $post_and_comment->user->image_pass }}" alt="" width="30">
+        <img src="{{ asset('storage/image/' . $post_and_comment->user->image_pass)}}" alt="" width="30"> 
+    @else
+        <img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="30">
+    @endif
+    <p>
+        <a href="{{ route('profile', ['user_id' => $post_and_comment->user_id]) }}">名前 : {{ $post_and_comment->user->name }}</a>
+        コメント時間 : {{ $post_and_comment->created_at }}
+    </p>
+    <p>{{$post_and_comment->comment}}</p>
+    <p>→いいね数 : {{count($post_and_comment->goods)}}</p>
+    @if ($post_and_comment->goods->contains('user_id', Auth::id()))
+        <a href="{{route('comment.delete_good', ['comment_id' => $post_and_comment->id])}}">いいね済み</a>
+    @elseif (Auth::check())
+        <a href="{{route('comment.good', ['comment_id' => $post_and_comment->id])}}">いいね</a>
+    @endif
+    <a href="{{ route('post.detail', ['post_id' => $post_and_comment->post_id]) }}">コメントした投稿を見る</a>
+
+    </br>
+    </br>
+    @endif
+
+    
+@endforeach
+{{ $posts_and_comments->links() }}
+@endif
+
+@endsection

--- a/resources/views/post/followed_post.blade.php
+++ b/resources/views/post/followed_post.blade.php
@@ -2,22 +2,15 @@
 
 @section('content')
 
-<h1>掲示版(フォローしているユーザーのみ)</h1>
+<h1>フォロー者投稿</h1>
 @if (empty($posts_and_comments)) 
-    <p>フォローユーザーの投稿とコメントはありません</p>
+    <p>投稿とコメントはありません</p>
 @else
-<p>
-    {{ ($posts_and_comments->currentPage()-1) * $posts_and_comments->perPage()+1 }} - 
-    {{ (($posts_and_comments->currentPage()-1) * $posts_and_comments->perPage()+1) + (count($posts_and_comments)-1) }} 件 
-
-    /{{ $posts_and_comments->total() }} 件を表示しています。
- </p>
  
 
 @foreach ($posts_and_comments as $post_and_comment)
     {{-- postか確認するコード --}}
     @if (!empty($post_and_comment->trouble_content))
-        <p>悩み投稿</p>
         @if ($post_and_comment->user->image_pass)
 		    <img src="{{ $post_and_comment->user->image_pass }}" alt="" width="30">
 		    <img src="{{ asset('storage/image/' . $post_and_comment->user->image_pass)}}" alt="" width="30"> 
@@ -79,7 +72,6 @@
     <br>
 
     @else
-    <p>コメント</p>
 
     @if ($post_and_comment->user->image_pass)
         <img src="{{ $post_and_comment->user->image_pass }}" alt="" width="30">

--- a/resources/views/profile/detail.blade.php
+++ b/resources/views/profile/detail.blade.php
@@ -24,7 +24,6 @@
 		<a href="{{ route('followers', ['followed_user_id' => $user->id])}}">{{ count($user->followed_user ) }}フォロワー</a>
 	</p>
 	<p>【名前】{{ $user->name }}</p>
-	<p>【メールアドレス】{{ $user->email }}</p>
 	<p>【年齢】
 	@if ($user->age)
 		{{ $user->age }}</p>
@@ -74,10 +73,11 @@
 @endif
 <hr>
 <div>家族加入保険</div>
-@if (Auth::id() == $user->id)
-	<a href="{{ route('family_ins.create') }}">家族加入保険追加</a>
-@endif
-<div>
+@if (Auth::check())
+	@if (Auth::id() == $user->id)
+		<a href="{{ route('family_ins.create') }}">家族加入保険追加</a>
+	@endif
+	<div>
 	@if ($family_insurances->isEmpty())
 		<p>登録無し</p>
 	@endif
@@ -94,6 +94,9 @@
 		<br>
 	@endforeach
 </div>
+@else
+<a href="{{ route('login') }}">ログイン者のみ家族加入保険を閲覧できます</a>
+@endif
 
 <hr>
 <div>投稿した悩み</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,7 +55,6 @@ Route::group(['prefix' => 'post', 'middleware' => 'auth:user'], function () {
 		Route::get('/good', 'CommentController@good')->name('comment.good');
 		Route::get('/good/delete', 'CommentController@deleteGood')->name('comment.delete_good');
 	});
-
 });
 
 Route::group(['prefix' => 'profile', 'middleware' => 'auth:user'], function () {
@@ -88,11 +87,13 @@ Route::group(['prefix' => 'chat', 'middleware' => 'auth:user'], function () {
 
 
 Route::group(['prefix' => 'relationship', 'middleware' => 'auth:user'], function () {
-	Route::get('/following', 'RelationshipController@following')->name('following');//フォロー中
-	Route::get('/followers', 'RelationshipController@followers')->name('followers');//フォロワー
+	Route::get('/following', 'RelationshipController@following')->name('following'); //フォロー中
+	Route::get('/followers', 'RelationshipController@followers')->name('followers'); //フォロワー
 	Route::get('/follow', 'RelationshipController@follow')->name('follow');
 	Route::get('/unfollow', 'RelationshipController@unfollow')->name('unfollow');
+	Route::get('/followed_content', 'RelationshipController@followedUsersPostsAndComments')->name('followed_content');
 });
+
 
 /*
  * Admin


### PR DESCRIPTION
【説明】
ログインユーザーがフォローしているユーザーの投稿とコメントのみ見れるページを作成
フォローしていることによるメリットを出すために本機能を作成しました。
実装したフォローしているユーザーの投稿とコメントを見れるページでは、投稿とコメントを最新の日付から並べております。詳細はそれぞれの投稿詳細画面に遷移するボタンを用意しております。

【コマンド】
特になし

【期待する結果】
・ヘッダーからフォローしているユーザーの投稿とコメントのみ見れるページへ遷移することができる。
・実際のページでは、フォローしているユーザーの悩み投稿とコメントが一覧でみることができる。