### PR TITLE
[add] DM一覧画面の作成

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -38,6 +38,12 @@ class ChatController extends Controller
         return view('chat/index', compact('receive_user', 'send_user'));
     }
 
+    public function list()
+    {
+        list($dm_started_list, $dm_not_started_list) = $this->chat->getChatListByUserId(Auth::id());
+		return view('chat/list', compact('dm_started_list', 'dm_not_started_list'));
+    }
+
     public function getData(User $receive_user, User $send_user)
 	{
         $chats = $this->chat->getChatsBetweenTwoPersons($receive_user->id, $send_user->id);

--- a/app/Models/Chat.php
+++ b/app/Models/Chat.php
@@ -10,6 +10,16 @@ class Chat extends Model
 {
 	use SoftDeletes;
 
+	public function send_user()
+	{
+		return $this->hasOne('App\Models\User', 'id', 'send_user_id');
+	}
+
+	public function receive_user()
+	{
+		return $this->hasOne('App\Models\User', 'id', 'receive_user_id');
+	}
+
 	protected $guarded = ['id'];
 
 	public function getChatsBetweenTwoPersons($receive_user_id, $send_user_id)
@@ -24,6 +34,58 @@ class Chat extends Model
 		return $chats;
 	}
 
+	public function getChatListByUserId($user_id)
+	{
+		//誰にchatを送信したか
+		$dm_started_user_list = $this->where('send_user_id', $user_id)->distinct()
+			->select('receive_user_id')->get();
+		//誰からchatが送信されたか
+		$dm_not_started_user_list = $this->where('receive_user_id', $user_id)->distinct()
+			->select('send_user_id')->get();
+
+		foreach ($dm_not_started_user_list as $key => $send_user) {
+			//既にchatを送信していたら除外
+			if (!empty($this->where('send_user_id', $user_id)->where('receive_user_id', $send_user->send_user_id)->first())) {
+				$dm_not_started_user_list->forget($key);
+			}
+		}
+		
+		//DM一覧を取得
+		$dm_started_chat_list = [];
+		foreach ($dm_started_user_list as $key => $dm_started_user) {
+			$dm_started_chat_list[$key]['user_id'] = $dm_started_user->receive_user_id;
+			$the_other_user = User::where('id', $dm_started_chat_list[$key]['user_id'])->first();
+			$dm_started_chat_list[$key]['user_name'] = $the_other_user->name;		
+			$dm_started_chat_list[$key]['image_pass'] = $the_other_user->image_pass;		
+			$dm_started_chat_list[$key]['message'] = $this->getLatestChatBetweenTwoPersons($dm_started_chat_list[$key]['user_id'], $user_id)->message;
+			$dm_started_chat_list[$key]['created_at'] = $this->getLatestChatBetweenTwoPersons($dm_started_chat_list[$key]['user_id'], $user_id)->created_at;			
+		}
+		
+		//まだ開始していないDM一覧を取得
+		$dm_not_started_chat_list = [];
+		foreach ($dm_not_started_user_list as $key => $dm_not_started_user) {
+			$dm_not_started_chat_list[$key]['user_id'] = $dm_not_started_user->send_user_id;
+
+			$the_other_user = User::where('id', $dm_not_started_chat_list[$key]['user_id'])->first();
+			$dm_not_started_chat_list[$key]['user_name'] = $the_other_user->name;		
+			$dm_not_started_chat_list[$key]['image_pass'] = $the_other_user->image_pass;		
+			$dm_not_started_chat_list[$key]['message'] = $this->getLatestChatBetweenTwoPersons($dm_not_started_chat_list[$key]['user_id'], $user_id)->message;
+			$dm_not_started_chat_list[$key]['created_at'] = $this->getLatestChatBetweenTwoPersons($dm_not_started_chat_list[$key]['user_id'], $user_id)->created_at;			
+		}
+		return [$dm_started_chat_list, $dm_not_started_chat_list];
+	}
+
+	public function getLatestChatBetweenTwoPersons($receive_user_id, $send_user_id)
+	{
+		$chat = $this->where(function($query) use ($receive_user_id, $send_user_id){
+			$query->where('receive_user_id', $receive_user_id)
+				->where('send_user_id', $send_user_id);
+		})->orWhere(function($query) use ($receive_user_id, $send_user_id) {
+			$query->where('receive_user_id', $send_user_id)
+				->where('send_user_id', $receive_user_id);
+		})->orderBy('created_at', 'desc')->first();
+		return $chat;
+	}
 
 	public function storeAndGetUpdatedChatList($request)
 	{

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -51,6 +51,18 @@ class User extends Authenticatable
 		return $this->hasMany('App\Models\Relationship', 'followed_id');
 	}
 
+	//chatを送信する人
+	public function send_user()
+	{
+		return $this->hasMany('App\Models\Chat', 'send_user_id');
+	}
+
+	//chatを送信される人
+	public function receive_user()
+	{
+		return $this->hasMany('App\Models\Chat', 'receive_user_id');
+	}
+
 	public function getDetailById($id)
 	{
 		$user = $this->where('id', $id)->firstOrFail();

--- a/composer.lock
+++ b/composer.lock
@@ -1002,16 +1002,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.5",
+            "version": "v4.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "4432ba399e47c66624bc73c8c0f811e5c109576f"
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4432ba399e47c66624bc73c8c0f811e5c109576f",
-                "reference": "4432ba399e47c66624bc73c8c0f811e5c109576f",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
                 "shasum": ""
             },
             "require": {
@@ -1050,7 +1050,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2021-05-03T19:11:20+00:00"
+            "time": "2021-07-21T10:44:31+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -1532,20 +1532,21 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v4.4.25",
+            "version": "v4.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "c1e29de6dc893b130b45d20d8051efbb040560a9"
+                "reference": "5194f18bd80d106f11efa8f7cd0fbdcc3af96ce6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/c1e29de6dc893b130b45d20d8051efbb040560a9",
-                "reference": "c1e29de6dc893b130b45d20d8051efbb040560a9",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/5194f18bd80d106f11efa8f7cd0fbdcc3af96ce6",
+                "reference": "5194f18bd80d106f11efa8f7cd0fbdcc3af96ce6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3"
+                "php": ">=7.1.3",
+                "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
             "autoload": {
@@ -1576,7 +1577,7 @@
             ],
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
-            "time": "2021-05-26T17:39:37+00:00"
+            "time": "2021-07-21T12:19:41+00:00"
         },
         {
             "name": "symfony/debug",
@@ -1631,21 +1632,22 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.4.25",
+            "version": "v4.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "047773e7016e4fd45102cedf4bd2558ae0d0c32f"
+                "reference": "958a128b184fcf0ba45ec90c0e88554c9327c2e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/047773e7016e4fd45102cedf4bd2558ae0d0c32f",
-                "reference": "047773e7016e4fd45102cedf4bd2558ae0d0c32f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/958a128b184fcf0ba45ec90c0e88554c9327c2e9",
+                "reference": "958a128b184fcf0ba45ec90c0e88554c9327c2e9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1.3",
-                "symfony/event-dispatcher-contracts": "^1.1"
+                "symfony/event-dispatcher-contracts": "^1.1",
+                "symfony/polyfill-php80": "^1.16"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4"
@@ -1655,7 +1657,7 @@
                 "symfony/event-dispatcher-implementation": "1.1"
             },
             "require-dev": {
-                "psr/log": "~1.0",
+                "psr/log": "^1|^2|^3",
                 "symfony/config": "^3.4|^4.0|^5.0",
                 "symfony/dependency-injection": "^3.4|^4.0|^5.0",
                 "symfony/error-handler": "~3.4|~4.4",
@@ -1693,7 +1695,7 @@
             ],
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
-            "time": "2021-05-26T17:39:37+00:00"
+            "time": "2021-07-23T15:41:52+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -2199,16 +2201,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.23.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
                 "shasum": ""
             },
             "require": {
@@ -2258,7 +2260,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2021-05-27T09:27:20+00:00"
+            "time": "2021-05-27T12:26:48+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
@@ -2420,6 +2422,72 @@
                 "shim"
             ],
             "time": "2021-05-27T09:17:38+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2021-07-28T13:41:28+00:00"
         },
         {
             "name": "symfony/process",
@@ -2903,16 +2971,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.13.0",
+            "version": "2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "2edbc73a4687d9085c8f20f398eebade844e8424"
+                "reference": "fdf92f03e150ed84d5967a833ae93abffac0315b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/2edbc73a4687d9085c8f20f398eebade844e8424",
-                "reference": "2edbc73a4687d9085c8f20f398eebade844e8424",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/fdf92f03e150ed84d5967a833ae93abffac0315b",
+                "reference": "fdf92f03e150ed84d5967a833ae93abffac0315b",
                 "shasum": ""
             },
             "require": {
@@ -2960,7 +3028,7 @@
                 "throwable",
                 "whoops"
             ],
-            "time": "2021-06-04T12:00:00+00:00"
+            "time": "2021-07-13T12:00:00+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -4394,6 +4462,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "abandoned": true,
             "time": "2015-07-28T20:34:47+00:00"
         },
         {

--- a/config/database.php
+++ b/config/database.php
@@ -50,7 +50,7 @@ return [
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',
-            'strict' => true,
+            'strict' => false,
             'engine' => null,
         ],
 

--- a/resources/views/chat/list.blade.php
+++ b/resources/views/chat/list.blade.php
@@ -1,0 +1,48 @@
+@extends('layouts.app')
+
+@section('content')
+
+<h1>DM一覧</h1>
+@foreach ($dm_started_list as $dm)
+	{{ $dm['user_name'] }}
+	@if ($dm['image_pass'])
+		<img src="{{ asset('storage/image/' . $dm['image_pass'])}}" alt="" width="50">
+	@else
+		<img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="50">
+	@endif
+	メッセージ : 
+	@if (mb_strlen($dm['message']) > 30)
+		{{ mb_substr($dm['message'], 0, 30) }}
+	@else
+		{{ $dm['message'] }}
+	    
+	@endif 
+	{{ $dm['created_at'] }}
+	<form action="{{ route('chat.index') }}" method="GET">
+		<input type="hidden" name="receive_user_id" value="{{ $dm['user_id'] }}">
+		<input type="hidden" name="send_user_id" value="{{ Auth::id() }}">
+		<button type="submit">DMを見る</button>
+	</form>
+	<hr>
+@endforeach
+
+<h1>まだ開始していないDM一覧</h1>
+@foreach ($dm_not_started_list as $dm)
+	{{ $dm['user_name'] }}
+	@if ($dm['image_pass'])
+		<img src="{{ asset('storage/image/' . $dm['image_pass'])}}" alt="" width="50">
+	@else
+		<img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="50">
+	@endif
+	メッセージ : {{ $dm['message'] }}
+	{{ $dm['created_at'] }}
+
+	<form action="{{ route('chat.index') }}" method="GET">
+		<input type="hidden" name="receive_user_id" value="{{ $dm['user_id'] }}">
+		<input type="hidden" name="send_user_id" value="{{ Auth::id() }}">
+		<button type="submit">DMを見る</button>
+	</form>
+	<hr>
+@endforeach
+
+@endsection

--- a/resources/views/chat/list.blade.php
+++ b/resources/views/chat/list.blade.php
@@ -10,7 +10,7 @@
 	@else
 		<img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="50">
 	@endif
-	メッセージ : 
+	最新メッセージ : 
 	@if (mb_strlen($dm['message']) > 30)
 		{{ mb_substr($dm['message'], 0, 30) }}
 	@else
@@ -26,7 +26,7 @@
 	<hr>
 @endforeach
 
-<h1>まだ開始していないDM一覧</h1>
+<h1>未返信DM</h1>
 @foreach ($dm_not_started_list as $dm)
 	{{ $dm['user_name'] }}
 	@if ($dm['image_pass'])
@@ -34,7 +34,7 @@
 	@else
 		<img src="{{ asset('storage/default/default.jpeg') }}" alt="" width="50">
 	@endif
-	メッセージ : {{ $dm['message'] }}
+	最新メッセージ : {{ $dm['message'] }}
 	{{ $dm['created_at'] }}
 
 	<form action="{{ route('chat.index') }}" method="GET">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -60,6 +60,7 @@
 
                                 <ul class="dropdown-menu">
 									<li><a href="{{ route('profile', ['id' => Auth::user()->id]) }}">プロフィール</a></li>
+									<li><a href="{{ route('chat.list') }}">DM一覧</a></li>
                                     <li>
                                         <a href="{{ route('logout') }}"
                                             onclick="event.preventDefault();

--- a/routes/web.php
+++ b/routes/web.php
@@ -84,6 +84,9 @@ Route::group(['prefix' => 'chat', 'middleware' => 'auth:user'], function () {
 	Route::post('/{receive_user}/{send_user}/send_message_api', 'ChatController@sendMessage');
 	Route::post('/{receive_user}/{send_user}/remove_message_api', 'ChatController@removeMessage');
 	Route::post('/{receive_user}/{send_user}/edit_message_api', 'ChatController@editMessage');
+
+	Route::get('/list', 'ChatController@list')->name('chat.list');
+
 });
 
 


### PR DESCRIPTION
【説明】
DM一覧画面の作成。グローバルメニューからDM一覧を見ることができます。

【コマンド】
特になし

【期待する結果】
開始しているDM一覧を見ることができる。
まだ開始していないDM一覧を見ることができる。

↑
2通りに場合分けしているのは、DBからダブりなくDM相手を取得するのが困難だったからです。
例えば、自分のuser_idが2だとして、
id  receive_user_id　send_user_id
1   2                             3
2   3                             2
3   1                             2
4   2                             4

というレコードがあって、DM相手との最新のmsgを一発で取得するのができなかったので、こういう処理にしています。
